### PR TITLE
Stop at empty truth line to prevent crash

### DIFF
--- a/gameboy-doctor
+++ b/gameboy-doctor
@@ -136,7 +136,7 @@ if __name__ == "__main__":
                 line_input = f_input.readline().strip()
                 line_truth = f_truth.readline().strip()
 
-                if line_input == "" and line_truth == "":
+                if line_truth == "":
                     output = SUCCESS_MESSAGE
                     output += "\n"
                     output += f"\nYour log file matched mine for all {line_n} lines - you passed the test ROM!"


### PR DESCRIPTION
## Problem

Currently, the end condition for matching all lines is if both the input/truth end with an empty line:

https://github.com/robert/gameboy-doctor/blob/d4dabd1f8b8ef2048f5a02c98f930b07780a30b0/gameboy-doctor#L139

If you were to pass an input with lines > truth, it will crash when trying to unpack the k/v from an empty string of the truth line:

https://github.com/robert/gameboy-doctor/blob/d4dabd1f8b8ef2048f5a02c98f930b07780a30b0/gameboy-doctor#L47

## Minimal Repro

1. Get an input with lines > truth lines (here's [mine](https://gist.github.com/robherley/65bdb53e74acd8c5620bf2d428b99b6a)):

```
wget https://gist.githubusercontent.com/robherley/65bdb53e74acd8c5620bf2d428b99b6a/raw/676380bd7466b9e57cfd0e88f167059b01805de3/cpu_instrs_6.txt
```

2. Run it:

```
./gameboy-doctor cpu_instrs_6.txt cpu_instrs 6
```

3. Error:

```
Traceback (most recent call last):
  File "/Users/robherley/dev/gameboy-doctor/./gameboy-doctor", line 180, in <module>
    truth_parsed = parse_line(line_truth)
  File "/Users/robherley/dev/gameboy-doctor/./gameboy-doctor", line 47, in parse_line
    k, v = kv.split(":")
ValueError: not enough values to unpack (expected 2, got 1)
```

## Solution

This tiny PR removes the unnecessary `line_input == ""` condition. Of course this assumes that all the truth files end in empty lines (which they do). A better solution may be to trim any whitespace and refactor the while condition to read until end of truth file. But this was a much easier fix 😄 

Thanks for this useful tool! Helped me catch some bugs in my instruction logic. Also super jealous you have the `@robert` gh handle
