### PR TITLE
Remove unneccessary unzipping

### DIFF
--- a/gameboy-doctor
+++ b/gameboy-doctor
@@ -31,12 +31,17 @@ INITIAL_STATE = {
 
 
 def unzip(rom_type, rom_n):
+
     zip_path = os.path.join("./truth/zipped", rom_type, f"{rom_n}.zip")
     unzip_dir = os.path.join("./truth/unzipped", rom_type)
-
+    dest = os.path.join(unzip_dir, f"{rom_n}.log")
     os.makedirs(unzip_dir, exist_ok=True)
-
+    
     with zipfile.ZipFile(zip_path, 'r') as zf:
+        size = sum([info.file_size for info in zf.infolist()])
+        if os.path.isfile(dest) and os.path.getsize(dest) == size:
+            return
+        
         zf.extractall(unzip_dir)
 
 


### PR DESCRIPTION
Stopped the program from unzipping the file if the log already exists and is already the same size as the estimated unpacked size. Helps with the huge logs i.e. 10