### PR TITLE
Display prefixed instruction

### DIFF
--- a/gameboy-doctor
+++ b/gameboy-doctor
@@ -95,16 +95,17 @@ with open("./opcode_annotations.json") as f:
 
 
 def operation(line):
-    op = []
     data = parse_line(line, True)
+    PCMEM = data["PCMEM"].split(",")
 
-    opcode = data["PCMEM"].split(",")[0].lower()
-    potential_opcode = data["PCMEM"].split(",")[1].lower()
- 
-    op.append(opcode_annotations["unprefixed"][f"0x{opcode}"]);
+    opcode = PCMEM[0].lower()
+    op = [opcode_annotations["unprefixed"][f"0x{opcode}"]]
 
-    if(opcode == 'cb'):
-        op.append(opcode_annotations["cbprefixed"][f"0x{potential_opcode}"])
+    if opcode == 'cb':
+        next_opcode = PCMEM[1].lower()
+        next_op = opcode_annotations["cbprefixed"][f"0x{next_opcode}"]
+
+        op.append(next_op)
 
     return op
 

--- a/gameboy-doctor
+++ b/gameboy-doctor
@@ -95,14 +95,18 @@ with open("./opcode_annotations.json") as f:
 
 
 def operation(line):
+    """
+    Returns a 2-element list of the CB opcode annotation and the following opcode annotation if next
+    op is CB, and a 1-element list of just the next opcode annotation otherwise.
+    """
     data = parse_line(line, True)
-    PCMEM = data["PCMEM"].split(",")
+    pcmem = data["PCMEM"].split(",")
 
-    opcode = PCMEM[0].lower()
+    opcode = pcmem[0].lower()
     op = [opcode_annotations["unprefixed"][f"0x{opcode}"]]
 
     if opcode == 'cb':
-        next_opcode = PCMEM[1].lower()
+        next_opcode = pcmem[1].lower()
         next_op = opcode_annotations["cbprefixed"][f"0x{next_opcode}"]
 
         op.append(next_op)

--- a/gameboy-doctor
+++ b/gameboy-doctor
@@ -95,10 +95,16 @@ with open("./opcode_annotations.json") as f:
 
 
 def operation(line):
+    op = []
     data = parse_line(line, True)
 
     opcode = data["PCMEM"].split(",")[0].lower()
-    op = opcode_annotations["unprefixed"][f"0x{opcode}"]
+    potential_opcode = data["PCMEM"].split(",")[1].lower()
+ 
+    op.append(opcode_annotations["unprefixed"][f"0x{opcode}"]);
+
+    if(opcode == 'cb'):
+        op.append(opcode_annotations["cbprefixed"][f"0x{potential_opcode}"])
 
     return op
 
@@ -228,7 +234,9 @@ if __name__ == "__main__":
                     output += "\n"
                     output += f"\nThe last operation executed (in between lines {line_n-1} and {line_n}) was:"
                     output += "\n"
-                    output += f"\n\t{op_sig(prev_op)}"
+                    output += f"\n\t{op_sig(prev_op[0])}"
+                    if len(prev_op) == 2:
+                        output += f" -> {op_sig(prev_op[1])}"
                     output += "\n"
                     output += "\nPerhaps the problem is with this opcode, or with your interrupt handling?"
 


### PR DESCRIPTION
Hello. First of all, I would like to thank you for this amazing tool, it has saved me so much time. The only issue(issue #16)  I had was that when a prefixed instruction was encountered, it would only print the prefix:
`0xCB PREFIX CB`
which was not extremely helpful. I made some small changes, so that it prints the prefixed instruction like this:
`0xCB PREFIX CB -> 0xA8 RES 5 B`

Thank you for your time. 